### PR TITLE
feat(feature-store): add Segment analytics tracking for Feature Store UI

### DIFF
--- a/packages/feature-store/src/FeatureStore.tsx
+++ b/packages/feature-store/src/FeatureStore.tsx
@@ -6,7 +6,12 @@ import {
   LineageCenterProvider,
   useLineageCenter,
 } from '@odh-dashboard/internal/components/lineage/context/LineageCenterContext';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import FeatureStoreProjectSelectorNavigator from './screens/components/FeatureStoreProjectSelectorNavigator';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from './tracking/featureStoreTrackingConstants';
 import FeatureStorePageTitle from './components/FeatureStorePageTitle';
 import FeatureStoreWarningAlert from './components/FeatureStoreWarningAlert';
 import ConnectedWorkbenchesLink from './components/ConnectedWorkbenchesLink';
@@ -90,6 +95,13 @@ const FeatureStoreInner: React.FC<FeatureStoreProps> = ({ ...pageProps }) => {
         <Tabs
           activeKey={activeTabKey}
           onSelect={(e, tabIndex) => {
+            if (tabIndex !== activeTabKey) {
+              fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+                tabName: String(tabIndex),
+                pageType: 'overview',
+                resourceType: 'featureStore',
+              } satisfies TabSwitchedProperties);
+            }
             setActiveTabKey(tabIndex);
           }}
           aria-label="Overview page"

--- a/packages/feature-store/src/components/FeatureStoreCodeBlock.tsx
+++ b/packages/feature-store/src/components/FeatureStoreCodeBlock.tsx
@@ -11,6 +11,11 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  FEATURE_STORE_EVENTS,
+  CodeCopiedProperties,
+} from '../tracking/featureStoreTrackingConstants';
 
 type FeatureStoreCodeBlockProps = {
   id: string;
@@ -39,6 +44,9 @@ const FeatureStoreCodeBlock: React.FC<FeatureStoreCodeBlockProps> = ({
   const onClick = (text: string) => {
     clipboardCopyFunc(text);
     setCopied(true);
+    fireMiscTrackingEvent(FEATURE_STORE_EVENTS.CODE_COPIED, {
+      resourceType: featureStoreType || 'resource',
+    } satisfies CodeCopiedProperties);
   };
 
   return (

--- a/packages/feature-store/src/components/FeatureStoreFilterToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreFilterToolbar.tsx
@@ -10,12 +10,17 @@ import {
   ToolbarItem,
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import {
   buildFilterLabelList,
   handleLabelDelete,
   getFilterOptionProps,
 } from '../utils/toolbarUtils';
 import { FeatureStoreFilterToolbarProps, FilterLabel } from '../types/toolbarTypes';
+import {
+  FEATURE_STORE_EVENTS,
+  FilterRemovedProperties,
+} from '../tracking/featureStoreTrackingConstants';
 
 function FeatureStoreFilterToolbar<T extends string>({
   filterOptions,
@@ -27,6 +32,7 @@ function FeatureStoreFilterToolbar<T extends string>({
   currentFilterType: externalCurrentFilterType,
   onFilterTypeChange,
   multipleLabels,
+  trackingResourceType,
   ...toolbarGroupProps
 }: FeatureStoreFilterToolbarProps<T>): React.JSX.Element {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -106,14 +112,19 @@ function FeatureStoreFilterToolbar<T extends string>({
                 categoryName={optionValue}
                 data-testid={`${testId}-text-field`}
                 labels={allActiveFilterItems}
-                deleteLabel={(category, labelToDelete) =>
+                deleteLabel={(category, labelToDelete) => {
+                  fireMiscTrackingEvent(FEATURE_STORE_EVENTS.FILTER_REMOVED, {
+                    action: 'removeOne',
+                    filterAttribute: String(filterKey),
+                    resourceType: trackingResourceType || 'unknown',
+                  } satisfies FilterRemovedProperties);
                   handleLabelDelete(
                     labelToDelete,
                     filterKey,
                     multipleLabels?.[filterKey] || [],
                     onFilterUpdate,
-                  )
-                }
+                  );
+                }}
                 showToolbarItem={currentFilterType === filterKey}
               >
                 {filterOptionRenders[filterKey](

--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/GlobalSearchInput.tsx
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/GlobalSearchInput.tsx
@@ -18,6 +18,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useSearchState } from './hooks/useSearchState';
 import { useSearchHandlers, type ISearchItem } from './hooks/useSearchHandlers';
 import { useResponsiveSearch } from './hooks/useResponsiveSearch';
@@ -25,6 +26,10 @@ import LoadMoreFooter from './LoadMoreFooter';
 import { groupResultsByCategory } from './utils/searchUtils';
 import useFeatureStoreProjects from '../../apiHooks/useFeatureStoreProjects';
 import FeatureStoreLabels from '../FeatureStoreLabels';
+import {
+  FEATURE_STORE_EVENTS,
+  SearchPerformedProperties,
+} from '../../tracking/featureStoreTrackingConstants';
 
 const highlightText = (textContent: string, searchTerm: string): React.ReactNode => {
   if (!searchTerm.trim()) return textContent;
@@ -110,10 +115,23 @@ const GlobalSearchInput: React.FC<ISearchInputProps> = ({
     onSearchChange,
     onClear,
     onSelect,
+    pageType: isDetailsPage ? 'detail' : 'list',
   });
   const searchInputContainerRef = React.useRef<HTMLDivElement>(null);
   const tooltipTriggerRef = React.useRef<HTMLDivElement>(null);
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
+
+  const prevLoadingRef = React.useRef(true);
+  React.useEffect(() => {
+    const query = searchState.searchValue.trim();
+    if (prevLoadingRef.current && !isLoading && query) {
+      fireMiscTrackingEvent(FEATURE_STORE_EVENTS.SEARCH_PERFORMED, {
+        resultCount: totalCount || searchResults.length,
+        pageType: isDetailsPage ? 'detail' : 'list',
+      } satisfies SearchPerformedProperties);
+    }
+    prevLoadingRef.current = isLoading;
+  }, [isLoading, totalCount, searchResults.length, isDetailsPage, searchState.searchValue]);
   const { searchInputStyle, searchMenuStyle } = useResponsiveSearch(
     searchState.isSmallScreen,
     searchInputContainerRef,

--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/hooks/useSearchHandlers.ts
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/hooks/useSearchHandlers.ts
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { UseSearchStateReturn } from './useSearchState';
 import { getFeatureStoreRoute } from '../utils/searchUtils';
+import {
+  FEATURE_STORE_EVENTS,
+  SearchResultSelectedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 
 export interface ISearchItem {
   id: string;
@@ -19,6 +24,7 @@ export interface UseSearchHandlersOptions {
   onClear?: () => void;
   onSelect?: (item: ISearchItem) => void;
   project?: string;
+  pageType?: 'overview' | 'list' | 'detail';
 }
 
 export interface UseSearchHandlersReturn {
@@ -31,7 +37,7 @@ export const useSearchHandlers = (
   state: UseSearchStateReturn,
   options: UseSearchHandlersOptions = {},
 ): UseSearchHandlersReturn => {
-  const { onSearchChange, onClear, onSelect, project } = options;
+  const { onSearchChange, onClear, onSelect, project, pageType } = options;
   const navigate = useNavigate();
 
   const { setSearchValue, setIsSearchOpen, setIsSearching, searchInputRef, searchMenuRef } = state;
@@ -78,6 +84,12 @@ export const useSearchHandlers = (
       setSearchValue('');
       setIsSearchOpen(false);
 
+      fireMiscTrackingEvent(FEATURE_STORE_EVENTS.SEARCH_RESULT_SELECTED, {
+        resultType: selectedItem.type,
+        pageType: pageType || 'list',
+        resourceType: selectedItem.type,
+      } satisfies SearchResultSelectedProperties);
+
       if (onSelect) {
         onSelect(selectedItem);
       }
@@ -95,7 +107,7 @@ export const useSearchHandlers = (
         }
       }
     },
-    [onSelect, navigate, project, setSearchValue, setIsSearchOpen],
+    [onSelect, navigate, project, pageType, setSearchValue, setIsSearchOpen],
   );
 
   const handleSearchClear = React.useCallback(() => {

--- a/packages/feature-store/src/components/FeatureStoreLineageToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineageToolbar.tsx
@@ -5,6 +5,7 @@ import {
   MultiSelection,
   type SelectionOptions,
 } from '@odh-dashboard/internal/components/MultiSelection';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import {
   extractFilterOptionsFromLineage,
   extractFilterOptionsFromFeatureViewLineage,
@@ -13,6 +14,10 @@ import {
   FeatureStoreLineageToolbarProps,
   FeatureStoreLineageSearchFilters,
 } from '../types/toolbarTypes';
+import {
+  FEATURE_STORE_EVENTS,
+  LineageFilterAppliedProperties,
+} from '../tracking/featureStoreTrackingConstants';
 
 type FilterOptionRenders = {
   onChange: (value?: string, label?: string) => void;
@@ -98,9 +103,13 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
           delete newFilters[filterType];
         }
         onSearchFiltersChange(newFilters);
+        fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_FILTER_APPLIED, {
+          filterType: String(filterType),
+          pageType: isFeatureViewToolbar ? 'detail' : 'overview',
+        } satisfies LineageFilterAppliedProperties);
       }
     },
-    [onSearchFiltersChange, searchFilters],
+    [onSearchFiltersChange, searchFilters, isFeatureViewToolbar],
   );
 
   const getEntityOptions = useMemo(() => {
@@ -334,7 +343,14 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
             id="hide-nodes-without-relationships"
             label="Hide nodes without relationships"
             isChecked={hideNodesWithoutRelationships}
-            onChange={(_event, checked) => onHideNodesWithoutRelationshipsChange(checked)}
+            onChange={(_event, checked) => {
+              fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_FILTER_APPLIED, {
+                filterType: 'hideNodesWithoutRelationships',
+                hideObjects: checked,
+                pageType: isFeatureViewToolbar ? 'detail' : 'overview',
+              } satisfies LineageFilterAppliedProperties);
+              onHideNodesWithoutRelationshipsChange(checked);
+            }}
             aria-label="Toggle visibility of nodes without relationships"
           />
         </ToolbarItem>

--- a/packages/feature-store/src/components/FeatureStoreToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreToolbar.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import { SearchInput } from '@patternfly/react-core';
 import DashboardDatePicker from '@odh-dashboard/internal/components/DashboardDatePicker';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import FeatureStoreFilterToolbar from './FeatureStoreFilterToolbar';
 import { BaseFilterOptionRenders } from '../types/toolbarTypes';
+import {
+  FEATURE_STORE_EVENTS,
+  FilterAppliedProperties,
+} from '../tracking/featureStoreTrackingConstants';
 
 export type FilterOptionRenders = BaseFilterOptionRenders & {
   'aria-label'?: string;
@@ -22,6 +27,7 @@ export type BaseFeatureStoreToolbarProps = {
   children?: React.ReactNode;
   currentFilterType?: string;
   onFilterTypeChange?: (filterType: string) => void;
+  trackingResourceType?: string;
 };
 
 export type FeatureStoreToolbarProps = BaseFeatureStoreToolbarProps & Partial<TagFilterProps>;
@@ -68,7 +74,8 @@ const TagMultiInput: React.FC<{
   onTagFilterAdd?: (tag: string) => void;
   onChange: (value?: string, label?: string) => void;
   value?: string;
-}> = ({ tagFilters = [], onTagFilterAdd, onChange, value }) => {
+  trackingResourceType?: string;
+}> = ({ tagFilters = [], onTagFilterAdd, onChange, value, trackingResourceType }) => {
   const [localValue, setLocalValue] = React.useState(value || '');
   React.useEffect(() => {
     if (value === undefined || value === '') {
@@ -82,6 +89,10 @@ const TagMultiInput: React.FC<{
       const newTag = localValue.trim();
       if (!tagFilters.includes(newTag)) {
         onTagFilterAdd?.(newTag);
+        fireMiscTrackingEvent(FEATURE_STORE_EVENTS.FILTER_APPLIED, {
+          filterAttribute: 'tag',
+          resourceType: trackingResourceType || 'unknown',
+        } satisfies FilterAppliedProperties);
         setLocalValue('');
         onChange('');
       }
@@ -107,6 +118,7 @@ export function createDefaultFilterOptionRenders(
   filterOptions: Record<string, string>,
   tagFilters?: string[],
   onTagFilterAdd?: (tag: string) => void,
+  trackingResourceType?: string,
 ): Record<string, (props: FilterOptionRenders) => React.ReactNode> {
   const result: Record<string, (props: FilterOptionRenders) => React.ReactNode> = {};
   for (const key of Object.keys(filterOptions)) {
@@ -117,6 +129,7 @@ export function createDefaultFilterOptionRenders(
           onTagFilterAdd={onTagFilterAdd}
           onChange={props.onChange}
           value={props.value}
+          trackingResourceType={trackingResourceType}
         />
       );
     } else if (key === 'created' || key === 'updated') {
@@ -128,6 +141,12 @@ export function createDefaultFilterOptionRenders(
           onChange={(_, value, date) => {
             if (date || !value) {
               onChange(value);
+              if (date) {
+                fireMiscTrackingEvent(FEATURE_STORE_EVENTS.FILTER_APPLIED, {
+                  filterAttribute: key,
+                  resourceType: trackingResourceType || 'unknown',
+                } satisfies FilterAppliedProperties);
+              }
             }
           }}
         />
@@ -153,13 +172,20 @@ export function FeatureStoreToolbar({
   children,
   currentFilterType,
   onFilterTypeChange,
+  trackingResourceType,
   tagFilters = [],
   onTagFilterRemove,
   onTagFilterAdd,
 }: FeatureStoreToolbarProps): JSX.Element {
   const filterOptionRenders = React.useMemo(
-    () => createDefaultFilterOptionRenders(filterOptions, tagFilters, onTagFilterAdd),
-    [filterOptions, tagFilters, onTagFilterAdd],
+    () =>
+      createDefaultFilterOptionRenders(
+        filterOptions,
+        tagFilters,
+        onTagFilterAdd,
+        trackingResourceType,
+      ),
+    [filterOptions, tagFilters, onTagFilterAdd, trackingResourceType],
   );
 
   const multipleLabels = React.useMemo(() => {
@@ -177,23 +203,17 @@ export function FeatureStoreToolbar({
     };
   }, [tagFilters, onTagFilterRemove]);
 
-  const customOnFilterUpdate = React.useCallback(
-    (key: string, value?: string | { label: string; value: string }) => {
-      onFilterUpdate(key, value);
-    },
-    [onFilterUpdate],
-  );
-
   return (
     <FeatureStoreFilterToolbar<keyof typeof filterOptions>
       data-testid="feature-store-table-toolbar"
       filterOptions={filterOptions}
       filterOptionRenders={filterOptionRenders}
       filterData={filterData}
-      onFilterUpdate={customOnFilterUpdate}
+      onFilterUpdate={onFilterUpdate}
       currentFilterType={currentFilterType}
       onFilterTypeChange={onFilterTypeChange}
       multipleLabels={multipleLabels}
+      trackingResourceType={trackingResourceType}
     >
       {children}
     </FeatureStoreFilterToolbar>

--- a/packages/feature-store/src/components/IntegrationInstructionsPopover.tsx
+++ b/packages/feature-store/src/components/IntegrationInstructionsPopover.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { Popover, Stack, StackItem, Button } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  FEATURE_STORE_EVENTS,
+  HelpViewedProperties,
+} from '../tracking/featureStoreTrackingConstants';
 
 type IntegrationInstructionsPopoverProps = {
   trigger?: React.ReactElement;
@@ -57,6 +62,13 @@ const IntegrationInstructionsPopover: React.FC<IntegrationInstructionsPopoverPro
       bodyContent={popoverContent}
       className={className}
       data-testid="integration-instructions-popover"
+      shouldOpen={() => {
+        fireMiscTrackingEvent(FEATURE_STORE_EVENTS.HELP_VIEWED, {
+          helpType: 'integration',
+          pageType: 'overview',
+        } satisfies HelpViewedProperties);
+        return true;
+      }}
     >
       {trigger || (
         <Button

--- a/packages/feature-store/src/screens/components/FeatureStoreInfoTooltip.tsx
+++ b/packages/feature-store/src/screens/components/FeatureStoreInfoTooltip.tsx
@@ -2,6 +2,11 @@ import * as React from 'react';
 import { Flex, Popover, Stack, StackItem, Title } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  FEATURE_STORE_EVENTS,
+  HelpViewedProperties,
+} from '../../tracking/featureStoreTrackingConstants';
 
 type FeatureStoreInfoTooltipProps = {
   wrap?: boolean;
@@ -22,6 +27,13 @@ const FeatureStoreInfoTooltip: React.FC<FeatureStoreInfoTooltipProps> = ({
     >
       <Popover
         position="top"
+        shouldOpen={() => {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.HELP_VIEWED, {
+            helpType: 'columnInfo',
+            pageType: 'detail',
+          } satisfies HelpViewedProperties);
+          return true;
+        }}
         bodyContent={
           <Stack hasGutter>
             {title && (

--- a/packages/feature-store/src/screens/components/FeatureStoreProjectSelectorNavigator.tsx
+++ b/packages/feature-store/src/screens/components/FeatureStoreProjectSelectorNavigator.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import FeatureStoreProjectSelector from './FeatureStoreProjectSelector';
 import { useFeatureStoreObject } from '../../apiHooks/useFeatureStoreObject';
 import { FeatureStoreObject } from '../../const';
 import { useFeatureStoreProject } from '../../FeatureStoreContext';
+import useFeatureStoreProjects from '../../apiHooks/useFeatureStoreProjects';
+import {
+  FEATURE_STORE_EVENTS,
+  ProjectSelectedProperties,
+} from '../../tracking/featureStoreTrackingConstants';
 
 type FeatureStoreProjectSelectorNavigatorProps = {
   getRedirectPath: (featureStoreObject: FeatureStoreObject, featureStoreProject?: string) => string;
@@ -15,10 +21,16 @@ const FeatureStoreProjectSelectorNavigator: React.FC<FeatureStoreProjectSelector
   const navigate = useNavigate();
   const currentFeatureStoreObject = useFeatureStoreObject();
   const { currentProject, updatePreferredFeatureStoreProject } = useFeatureStoreProject();
+  const { data: featureStoreProjects } = useFeatureStoreProjects();
 
   return (
     <FeatureStoreProjectSelector
       onSelection={(featureStoreObject: FeatureStoreObject, featureStoreProject?: string) => {
+        fireMiscTrackingEvent(FEATURE_STORE_EVENTS.PROJECT_SELECTED, {
+          isSwitch: !!currentProject && currentProject !== (featureStoreProject || ''),
+          storeCount: featureStoreProjects.projects.length,
+          pageType: currentFeatureStoreObject === FeatureStoreObject.OVERVIEW ? 'overview' : 'list',
+        } satisfies ProjectSelectedProperties);
         updatePreferredFeatureStoreProject(featureStoreProject || null);
         navigate(getRedirectPath(featureStoreObject, featureStoreProject));
       }}

--- a/packages/feature-store/src/screens/dataSets/DataSetDetails/DataSetDetailsTabs.tsx
+++ b/packages/feature-store/src/screens/dataSets/DataSetDetails/DataSetDetailsTabs.tsx
@@ -2,12 +2,17 @@ import { PageSection, Tab, Tabs, TabTitleText, Title } from '@patternfly/react-c
 import * as React from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import DataSetDetailsView from './DataSetDetailsView';
 import { useFeatureStoreProject } from '../../../FeatureStoreContext';
 import { featureViewRoute } from '../../../routes';
 import { DataSetDetailsTab } from '../const';
 import { DataSet } from '../../../types/dataSets';
 import { featureRoute } from '../../../FeatureStoreRoutes';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 
 type DataSetDetailsTabsProps = {
   dataSet: DataSet;
@@ -28,6 +33,13 @@ const DataSetDetailsTabs: React.FC<DataSetDetailsTabsProps> = ({ dataSet }) => {
       mountOnEnter
       unmountOnExit
       onSelect={(e, tabIndex) => {
+        if (tabIndex !== activeTabKey) {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+            tabName: String(tabIndex),
+            pageType: 'detail',
+            resourceType: 'dataset',
+          } satisfies TabSwitchedProperties);
+        }
         setActiveTabKey(tabIndex);
       }}
     >

--- a/packages/feature-store/src/screens/dataSets/DataSetTable/FeatureStoreDatasetListView.tsx
+++ b/packages/feature-store/src/screens/dataSets/DataSetTable/FeatureStoreDatasetListView.tsx
@@ -64,6 +64,7 @@ const FeatureStoreDataSetsListView = ({
           tagFilters={tagFilters}
           onTagFilterRemove={tagHandlers.handleTagFilterRemove}
           onTagFilterAdd={tagHandlers.handleTagFilterAdd}
+          trackingResourceType="dataset"
         />
       }
     />

--- a/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceTabs.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceTabs.tsx
@@ -15,10 +15,15 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { SearchIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import DataSourceDetailsView from './DataSourceDetailsView';
 import { DataSourceDetailsTab } from '../const';
 import { DataSource } from '../../../types/dataSources';
 import { useFeatureStoreProject } from '../../../FeatureStoreContext';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 import useFeatureViews from '../../../apiHooks/useFeatureViews';
 import { getRelationshipsByTargetType } from '../../../utils/filterUtils';
 import ScrollableLinksPopover from '../../../components/ScrollableLinksPopover';
@@ -166,6 +171,13 @@ const DataSourceDetailsTabs: React.FC<DataSourceDetailsTabsProps> = ({ dataSourc
       mountOnEnter
       unmountOnExit
       onSelect={(e, tabIndex) => {
+        if (tabIndex !== activeTabKey) {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+            tabName: String(tabIndex),
+            pageType: 'detail',
+            resourceType: 'dataSource',
+          } satisfies TabSwitchedProperties);
+        }
         setActiveTabKey(tabIndex);
       }}
     >

--- a/packages/feature-store/src/screens/dataSources/dataSourceTable/FeatureStoreDataSourceListView.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceTable/FeatureStoreDataSourceListView.tsx
@@ -69,6 +69,7 @@ const FeatureStoreDataSourceListView = ({
           filterOptions={dynamicFilterOptions}
           filterData={filterData}
           onFilterUpdate={onFilterUpdate}
+          trackingResourceType="dataSource"
         />
       }
     />

--- a/packages/feature-store/src/screens/entities/EntitiesDetails/EntityDetailsTabs.tsx
+++ b/packages/feature-store/src/screens/entities/EntitiesDetails/EntityDetailsTabs.tsx
@@ -1,9 +1,14 @@
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import * as React from 'react';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import EntityDetailsView from './EntityDetailsView';
 import { Entity } from '../../../types/entities';
 import FeatureViewTab from '../../components/FeatureViewTab';
 import { EntityDetailsTab } from '../const';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 
 type EntityDetailsTabsProps = {
   entity: Entity;
@@ -19,6 +24,13 @@ const EntityDetailsTabs: React.FC<EntityDetailsTabsProps> = ({ entity }) => {
       role="region"
       data-testid="entity-details-page"
       onSelect={(e, tabIndex) => {
+        if (tabIndex !== activeTabKey) {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+            tabName: String(tabIndex),
+            pageType: 'detail',
+            resourceType: 'entity',
+          } satisfies TabSwitchedProperties);
+        }
         setActiveTabKey(tabIndex);
       }}
     >

--- a/packages/feature-store/src/screens/entities/EntitiesTable/FeatureStoreEntitiesListView.tsx
+++ b/packages/feature-store/src/screens/entities/EntitiesTable/FeatureStoreEntitiesListView.tsx
@@ -66,6 +66,7 @@ const FeatureStoreEntitiesListView = ({
           tagFilters={tagFilters}
           onTagFilterRemove={tagHandlers.handleTagFilterRemove}
           onTagFilterAdd={tagHandlers.handleTagFilterAdd}
+          trackingResourceType="entity"
         />
       }
     />

--- a/packages/feature-store/src/screens/featureServices/FeatureServicesListView.tsx
+++ b/packages/feature-store/src/screens/featureServices/FeatureServicesListView.tsx
@@ -71,6 +71,7 @@ const FeatureServicesListView = ({
           tagFilters={tagFilters}
           onTagFilterRemove={tagHandlers.handleTagFilterRemove}
           onTagFilterAdd={tagHandlers.handleTagFilterAdd}
+          trackingResourceType="featureService"
         />
       }
     />

--- a/packages/feature-store/src/screens/featureServices/featureServiceDetails/FeatureServiceDetailsTabs.tsx
+++ b/packages/feature-store/src/screens/featureServices/featureServiceDetails/FeatureServiceDetailsTabs.tsx
@@ -1,9 +1,14 @@
 import { PageSection, Tab, TabContentBody, Tabs, TabTitleText } from '@patternfly/react-core';
 import * as React from 'react';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import FeatureServiceDetailsPage from './FeatureServiceDetailsPage';
 import { FeatureService } from '../../../types/featureServices';
 import FeatureViewTab from '../../components/FeatureViewTab';
 import { FeatureServiceDetailsTab } from '../const';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 
 type FeatureServiceDetailsTabsProps = {
   featureService: FeatureService;
@@ -25,6 +30,13 @@ const FeatureServiceDetailsTabs: React.FC<FeatureServiceDetailsTabsProps> = ({
       role="region"
       data-testid="feature-service-details-tabs"
       onSelect={(e, tabIndex) => {
+        if (tabIndex !== activeTabKey) {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+            tabName: String(tabIndex),
+            pageType: 'detail',
+            resourceType: 'featureService',
+          } satisfies TabSwitchedProperties);
+        }
         setActiveTabKey(tabIndex);
       }}
     >

--- a/packages/feature-store/src/screens/featureViews/FeatureViewsListView.tsx
+++ b/packages/feature-store/src/screens/featureViews/FeatureViewsListView.tsx
@@ -130,6 +130,7 @@ const FeatureViewsListView = ({
           tagFilters={tagFilters}
           onTagFilterRemove={tagHandlers.handleTagFilterRemove}
           onTagFilterAdd={tagHandlers.handleTagFilterAdd}
+          trackingResourceType="featureView"
         />
       }
     />

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
@@ -139,6 +139,7 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
           filterOptions={schemaFilterOptions}
           filterData={filterData}
           onFilterUpdate={onFilterUpdate}
+          trackingResourceType="featureView"
         />
       }
       onClearFilters={onClearFilters}

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewTabs.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewTabs.tsx
@@ -4,6 +4,7 @@ import {
   LineageCenterProvider,
   useLineageCenter,
 } from '@odh-dashboard/internal/components/lineage/context/LineageCenterContext';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import FeatureViewLineageTab from './FeatureViewLineageTab';
 import FeatureViewDetailsView from './FeatureViewDetailsTab';
 import FeatureViewMaterialization from './FeatureViewMaterialization';
@@ -11,6 +12,10 @@ import FeatureViewTransformation from './FeatureViewTransformation';
 import FeatureViewConsumingTab from './FeatureViewConsumingTab';
 import { FeatureView } from '../../../types/featureView';
 import FeatureStoreInfoTooltip from '../../components/FeatureStoreInfoTooltip';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 import { FeatureViewTab } from '../const';
 
 type FeatureViewTabsProps = {
@@ -44,6 +49,13 @@ const FeatureViewTabsInner: React.FC<FeatureViewTabsProps> = ({ featureView }) =
       role="region"
       data-testid="feature-view-details-page"
       onSelect={(e, tabIndex) => {
+        if (tabIndex !== activeTabKey) {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+            tabName: String(tabIndex),
+            pageType: 'detail',
+            resourceType: 'featureView',
+          } satisfies TabSwitchedProperties);
+        }
         setActiveTabKey(tabIndex);
       }}
     >

--- a/packages/feature-store/src/screens/features/FeaturesList.tsx
+++ b/packages/feature-store/src/screens/features/FeaturesList.tsx
@@ -71,6 +71,7 @@ const FeaturesList = ({
           tagFilters={tagFilters}
           onTagFilterRemove={tagHandlers.handleTagFilterRemove}
           onTagFilterAdd={tagHandlers.handleTagFilterAdd}
+          trackingResourceType="feature"
         />
       }
     />

--- a/packages/feature-store/src/screens/features/featureDetails/FeatureDetailsTab.tsx
+++ b/packages/feature-store/src/screens/features/featureDetails/FeatureDetailsTab.tsx
@@ -14,6 +14,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import * as React from 'react';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { Features } from '../../../types/features';
 import { FeatureStoreSections, hasContent } from '../../../const';
 import FeatureStoreTags from '../../../components/FeatureStoreTags';
@@ -21,6 +22,10 @@ import FeatureStoreCodeBlock from '../../../components/FeatureStoreCodeBlock';
 import FeatureStoreInfoTooltip from '../../components/FeatureStoreInfoTooltip';
 import FeatureViewTab from '../../components/FeatureViewTab';
 import { FeatureDetailsTab } from '../const';
+import {
+  FEATURE_STORE_EVENTS,
+  TabSwitchedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 
 type FeatureDetailsTabsProps = {
   feature: Features;
@@ -38,6 +43,13 @@ const FeatureDetailsTabs: React.FC<FeatureDetailsTabsProps> = ({ feature }) => {
       role="region"
       data-testid="feature-details-page"
       onSelect={(e, tabIndex) => {
+        if (tabIndex !== activeTabKey) {
+          fireMiscTrackingEvent(FEATURE_STORE_EVENTS.TAB_SWITCHED, {
+            tabName: String(tabIndex),
+            pageType: 'detail',
+            resourceType: 'feature',
+          } satisfies TabSwitchedProperties);
+        }
         setActiveTabKey(tabIndex);
       }}
     >

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
@@ -20,7 +20,12 @@ import {
   LineageSourceAnchor,
   LineageTargetAnchor,
 } from '@odh-dashboard/internal/components/lineage/anchors/customAnchors';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { getEntityTypeIcon } from '../../../utils/featureStoreObjects.tsx';
+import {
+  FEATURE_STORE_EVENTS,
+  LineageNodeSelectedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 
 type LineageNodeProps = {
   element: GraphElement;
@@ -98,19 +103,22 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
           }
         }
 
-        // Store click position and pill element for popover positioning
         setClickPosition({
           x: e.clientX,
           y: e.clientY,
           pillElement: pillElement?.tagName === 'rect' ? pillElement : null,
         });
 
-        // Call original selection handler with proper signature
+        fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_NODE_SELECTED, {
+          nodeType: data?.entityType || 'unknown',
+          pageType: 'detail',
+        } satisfies LineageNodeSelectedProperties);
+
         if (onSelect) {
           onSelect(e);
         }
       },
-      [setClickPosition, onSelect],
+      [setClickPosition, onSelect, data?.entityType],
     );
 
     // Get node bounds for positioning

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
@@ -14,6 +14,11 @@ import {
 } from '@patternfly/react-core';
 import { LineageNode } from '@odh-dashboard/internal/components/lineage/types';
 import { useLineageClick } from '@odh-dashboard/internal/components/lineage/LineageClickContext';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  FEATURE_STORE_EVENTS,
+  LineageNavigationPerformedProperties,
+} from '../../../tracking/featureStoreTrackingConstants';
 import {
   featureDataSourceRoute,
   featureEntityRoute,
@@ -171,6 +176,12 @@ const FeatureStoreLineageNodePopover: React.FC<FeatureStoreLineageNodePopoverPro
                     : 'button'
                 }
                 isDisabled={!detailsRoute}
+                onClick={() => {
+                  fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_NAVIGATION_PERFORMED, {
+                    targetResourceType: node.fsObjectTypes,
+                    pageType: 'detail',
+                  } satisfies LineageNavigationPerformedProperties);
+                }}
               >
                 View {getFsObjectTypeLabel(node.fsObjectTypes)} page
               </Button>
@@ -183,6 +194,12 @@ const FeatureStoreLineageNodePopover: React.FC<FeatureStoreLineageNodePopoverPro
                 component={(props: React.ComponentProps<'a'>) => (
                   <Link {...props} to={allFeaturesHref} />
                 )}
+                onClick={() => {
+                  fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_NAVIGATION_PERFORMED, {
+                    targetResourceType: 'feature',
+                    pageType: 'detail',
+                  } satisfies LineageNavigationPerformedProperties);
+                }}
               >
                 View all features
               </Button>

--- a/packages/feature-store/src/screens/metrics/MetricCards.tsx
+++ b/packages/feature-store/src/screens/metrics/MetricCards.tsx
@@ -17,10 +17,15 @@ import {
   Truncate,
 } from '@patternfly/react-core';
 import TruncatedText from '@odh-dashboard/internal/components/TruncatedText';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { MetricCardItem, processMetricsData } from './utils';
 import { MetricsCountResponse } from '../../types/metrics';
 import FeatureStoreObjectIcon from '../../components/FeatureStoreObjectIcon';
 import { getFeatureStoreObjectTypeFromTitle } from '../../utils';
+import {
+  FEATURE_STORE_EVENTS,
+  OverviewCardClickedProperties,
+} from '../../tracking/featureStoreTrackingConstants';
 
 type MetricCardsProps = {
   metricsData?: MetricsCountResponse;
@@ -61,7 +66,16 @@ const MetricCard = ({ item, loaded }: { item: MetricCardItem; loaded: boolean })
       <CardFooter>
         {loaded ? (
           totalCount > 0 ? (
-            <Link to={item.route} aria-label={`Go to ${item.title} page`}>
+            <Link
+              to={item.route}
+              aria-label={`Go to ${item.title} page`}
+              onClick={() => {
+                fireMiscTrackingEvent(FEATURE_STORE_EVENTS.OVERVIEW_CARD_CLICKED, {
+                  cardType: 'resourceSummary',
+                  targetResourceType: getFeatureStoreObjectTypeFromTitle(item.title),
+                } satisfies OverviewCardClickedProperties);
+              }}
+            >
               Go to <b>{item.title}</b>
             </Link>
           ) : (

--- a/packages/feature-store/src/screens/metrics/PopularTags.tsx
+++ b/packages/feature-store/src/screens/metrics/PopularTags.tsx
@@ -22,7 +22,12 @@ import { PlusIcon, TagIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import TruncatedText from '@odh-dashboard/internal/components/TruncatedText';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { EMPTY_STATE_MESSAGES } from './const';
+import {
+  FEATURE_STORE_EVENTS,
+  PopularTagClickedProperties,
+} from '../../tracking/featureStoreTrackingConstants';
 import useMetricsPopularTags from '../../apiHooks/useMetricsPopularTags';
 import { FeatureStoreObject } from '../../const';
 import { featureStoreRoute, featureViewRoute } from '../../routes';
@@ -68,6 +73,11 @@ const PopularTagCard = ({ tag }: { tag: PopularTag }) => {
               <Link
                 to={featureViewRoute(featureView.name, featureView.project)}
                 aria-label={`Go to ${featureView.name} feature view in ${featureView.project} project`}
+                onClick={() => {
+                  fireMiscTrackingEvent(FEATURE_STORE_EVENTS.POPULAR_TAG_CLICKED, {
+                    clickTarget: 'featureViewLink',
+                  } satisfies PopularTagClickedProperties);
+                }}
               >
                 {featureView.name}
               </Link>
@@ -79,6 +89,11 @@ const PopularTagCard = ({ tag }: { tag: PopularTag }) => {
         <Link
           to={featureStoreRoute(FeatureStoreObject.FEATURE_VIEWS)}
           aria-label={`View all ${tag.total_feature_views} feature views for ${tag.tag_key}: ${tag.tag_value}`}
+          onClick={() => {
+            fireMiscTrackingEvent(FEATURE_STORE_EVENTS.POPULAR_TAG_CLICKED, {
+              clickTarget: 'viewAllButton',
+            } satisfies PopularTagClickedProperties);
+          }}
         >
           View all ({tag.total_feature_views})
         </Link>

--- a/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
+++ b/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
@@ -14,10 +14,15 @@ import { PathMissingIcon, PlusIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { recentlyVisitedResourcesColumns, EMPTY_STATE_MESSAGES } from './const';
 import { formatResourceType, getResourceRoute } from './utils';
 import useRecentlyVisitedResources from '../../apiHooks/useRecentlyVisitedResources';
 import { RecentlyVisitedResource } from '../../types/metrics';
+import {
+  FEATURE_STORE_EVENTS,
+  RecentlyViewedSelectedProperties,
+} from '../../tracking/featureStoreTrackingConstants';
 
 type RecentlyVisitedResourcesProps = {
   project?: string;
@@ -35,6 +40,11 @@ const RecentlyVisitedResourcesTableRow: React.FC<{
         <Link
           to={resourceLink}
           aria-label={`Go to ${item.object_name} ${resourceType} in ${item.project} project`}
+          onClick={() => {
+            fireMiscTrackingEvent(FEATURE_STORE_EVENTS.RECENTLY_VIEWED_SELECTED, {
+              resourceType,
+            } satisfies RecentlyViewedSelectedProperties);
+          }}
         >
           {item.object_name}
         </Link>

--- a/packages/feature-store/src/tracking/featureStoreTrackingConstants.ts
+++ b/packages/feature-store/src/tracking/featureStoreTrackingConstants.ts
@@ -1,0 +1,90 @@
+export const FEATURE_STORE_EVENTS = {
+  SEARCH_PERFORMED: 'Feature Store Search Performed',
+  SEARCH_RESULT_SELECTED: 'Feature Store Search Result Selected',
+  FILTER_APPLIED: 'Feature Store Filter Applied',
+  FILTER_REMOVED: 'Feature Store Filter Removed',
+  LINEAGE_NODE_SELECTED: 'Feature Store Lineage Node Selected',
+  LINEAGE_FILTER_APPLIED: 'Feature Store Lineage Filter Applied',
+  TAB_SWITCHED: 'Feature Store Tab Switched',
+  OVERVIEW_CARD_CLICKED: 'Feature Store Overview Card Clicked',
+  POPULAR_TAG_CLICKED: 'Feature Store Popular Tag Clicked',
+  RECENTLY_VIEWED_SELECTED: 'Feature Store Recently Viewed Selected',
+  LINEAGE_NAVIGATION_PERFORMED: 'Feature Store Lineage Navigation Performed',
+  CODE_COPIED: 'Feature Store Code Copied',
+  HELP_VIEWED: 'Feature Store Help Viewed',
+  PROJECT_SELECTED: 'Feature Store Project Selected',
+} as const;
+
+export type SearchPerformedProperties = {
+  resultCount: number;
+  pageType: 'overview' | 'list' | 'detail';
+  resourceType?: string;
+};
+
+export type SearchResultSelectedProperties = {
+  resultType: string;
+  pageType: 'overview' | 'list' | 'detail';
+  resourceType?: string;
+};
+
+export type FilterAppliedProperties = {
+  filterAttribute: string;
+  resourceType: string;
+};
+
+export type FilterRemovedProperties = {
+  action: 'removeOne' | 'clearAll';
+  filterAttribute?: string;
+  resourceType: string;
+};
+
+export type LineageNodeSelectedProperties = {
+  nodeType: string;
+  pageType: 'overview' | 'detail';
+};
+
+export type LineageFilterAppliedProperties = {
+  filterType: string;
+  hideObjects?: boolean;
+  pageType: 'overview' | 'detail';
+};
+
+export type TabSwitchedProperties = {
+  tabName: string;
+  pageType: 'overview' | 'detail';
+  resourceType: string;
+};
+
+export type OverviewCardClickedProperties = {
+  cardType: 'resourceSummary';
+  targetResourceType: string;
+};
+
+export type PopularTagClickedProperties = {
+  clickTarget: 'featureViewLink' | 'viewAllButton';
+};
+
+export type RecentlyViewedSelectedProperties = {
+  resourceType: string;
+};
+
+export type LineageNavigationPerformedProperties = {
+  targetResourceType: string;
+  pageType: 'overview' | 'detail';
+};
+
+export type CodeCopiedProperties = {
+  resourceType: string;
+};
+
+export type HelpViewedProperties = {
+  helpType: 'integration' | 'columnInfo' | 'codeHelp';
+  pageType: 'overview' | 'list' | 'detail';
+  resourceType?: string;
+};
+
+export type ProjectSelectedProperties = {
+  isSwitch: boolean;
+  storeCount: number;
+  pageType: 'overview' | 'list' | 'detail';
+};

--- a/packages/feature-store/src/types/toolbarTypes.ts
+++ b/packages/feature-store/src/types/toolbarTypes.ts
@@ -14,6 +14,7 @@ export type FeatureStoreFilterToolbarProps<T extends string> = React.ComponentPr
   currentFilterType?: T;
   onFilterTypeChange?: (filterType: T) => void;
   multipleLabels?: MultipleLabels<T>;
+  trackingResourceType?: string;
 };
 
 // Common types for toolbar functionality


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69916

## Description

Adds Segment analytics tracking to the Feature Store package (`packages/feature-store`), which previously had zero instrumentation. This implements 14 tracking events per the UX proposal in [RHOAIUX-2723](https://redhat.atlassian.net/browse/RHOAIUX-2723) and follows the [Segment Tracking Developer Guide](https://redhat.atlassian.net/wiki/spaces/RHODS/pages/422445562/Segment+Tracking+Developer+Guide).

### What was added

**New file:** `packages/feature-store/src/tracking/featureStoreTrackingConstants.ts`
- Centralized event constants (`FEATURE_STORE_EVENTS`) with `as const`
- Typed property interfaces for all 14 events (following the [eval-hub pattern](https://github.com/opendatahub-io/odh-dashboard/blob/main/packages/eval-hub/frontend/src/app/tracking/evalhubTrackingConstants.ts))

**14 tracking events across 29 modified files:**

| Category | Events | Files |
|---|---|---|
| Search | `Feature Store Search Performed`, `Search Result Selected` | `GlobalSearchInput.tsx`, `useSearchHandlers.ts` |
| Filters | `Filter Applied`, `Filter Removed` | `FeatureStoreFilterToolbar.tsx`, `FeatureStoreToolbar.tsx` + 7 list view consumers |
| Lineage | `Lineage Node Selected`, `Lineage Filter Applied`, `Lineage Navigation Performed` | `FeatureStoreLineageNode.tsx`, `FeatureStoreLineageToolbar.tsx`, `FeatureStoreLineageNodePopover.tsx` |
| Tab Navigation | `Tab Switched` | `FeatureStore.tsx` + 6 detail page tab components |
| Overview | `Overview Card Clicked`, `Popular Tag Clicked`, `Recently Viewed Selected` | `MetricCards.tsx`, `PopularTags.tsx`, `RecentlyVisitedResources.tsx` |
| Code | `Code Copied` | `FeatureStoreCodeBlock.tsx` |
| Help | `Help Viewed` | `IntegrationInstructionsPopover.tsx`, `FeatureStoreInfoTooltip.tsx` |
| Project Selector | `Project Selected` | `FeatureStoreProjectSelectorNavigator.tsx` |

### Key design decisions

- **No form tracking** — Feature Store is read-only (no create/edit/delete flows)
- **`fireMiscTrackingEvent` for all events** — `fireLinkTrackingEvent` has a fixed property schema that doesn't accept custom keys like `targetResourceType`
- **`satisfies` type assertions** at all call sites for compile-time validation against the property types
- **`trackingResourceType` prop** threaded through shared filter toolbar components so each list page correctly identifies its resource type
- **Filter tracking only on commit actions** — tag filters fire on Enter key, date filters on valid date selection; text SearchInput filters are not tracked per-keystroke (per the dev guide: "track the final action, not every keystroke")
- **Tab switch guard** (`if (tabIndex !== activeTabKey)`) prevents duplicate events on re-clicking the active tab
- **Dynamic `pageType`** derived from context (`isDetailsPage`, `isFeatureViewToolbar`, `currentFeatureStoreObject`) instead of hardcoded values

### Not in scope (blocked on unreleased features)

6 events from the [UX tracking doc](https://docs.google.com/document/d/1JkVFH-KfkiAF8dr6InzUUroOrMoseoQ_nESMq4kKbjk/edit) are deferred:
- `Feature Store View Toggled`, `Time Range Changed`, `System Health Filtered`, `System Health Filter Removed` — depend on monitoring feature
- `Feature Store Workbench Connection Viewed`, `Workbench Link Clicked` — `ConnectedWorkbenchesLink` is currently disabled

## How Has This Been Tested?

- Verified type-check passes: `npx turbo run type-check --filter=@odh-dashboard/feature-store` — 0 errors
- Verified lint passes: `npx turbo run lint --filter=@odh-dashboard/feature-store` — 0 errors (5 pre-existing warnings only)
- Lint-staged pre-commit hooks pass on all 30 files
- Tracking events can be verified in dev mode via browser console (`Telemetry event triggered:` logs)

## Test Impact

Unit tests for tracking calls are not included in this PR. The tracking code is purely additive and does not alter any existing behavior or control flow. Tracking-specific tests can be added as a follow-up following the eval-hub `*.tracking.spec.ts` pattern.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`